### PR TITLE
マップ機能追加完了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+
+/.env
 # Ignore bundler config.
 /.bundle
 
@@ -34,3 +36,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'materialize-sass', '~> 1.0.0'
 gem 'material_icons'
 gem 'bcrypt', '3.1.13'
 gem 'solargraph', group: :development
+gem 'geocoder'
+gem 'gon'
+gem 'dotenv-rails'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'will_paginate',           '3.1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     e2mmap (0.1.0)
     erubi (1.10.0)
     execjs (2.7.0)
@@ -100,8 +104,14 @@ GEM
       railties (>= 5.0.0)
     ffi (1.13.1)
     formatador (0.2.5)
+    geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     guard (2.16.2)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -151,6 +161,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     msgpack (1.3.3)
+    multi_json (1.15.0)
     mysql2 (0.5.3)
     nenv (0.3.0)
     nio4r (2.5.4)
@@ -214,6 +225,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.8.2)
+    request_store (1.5.0)
+      rack (>= 1.4)
     reverse_markdown (2.0.0)
       nokogiri
     rexml (3.2.4)
@@ -330,7 +343,10 @@ DEPENDENCIES
   bootstrap-will_paginate (= 1.0.0)
   byebug
   capybara (= 3.28.0)
+  dotenv-rails
   factory_bot_rails
+  geocoder
+  gon
   guard (= 2.16.2)
   guard-minitest (= 2.4.6)
   image_processing (= 1.9.3)

--- a/app/assets/stylesheets/maps.scss
+++ b/app/assets/stylesheets/maps.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the maps controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :logged_in?,only:[:create,:destroy]
+ # before_action :logged_in?,only:[:create,:destroy]
   before_action :correct_user,only:[:destroy]
 
     def new

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,19 @@
+class MapsController < ApplicationController
+
+  def new
+    @map = Map.new
+  end
+
+
+  def index
+    
+    @articles = []
+    @gmaps = Map.near(params[:area],20,units: :km)
+    
+    @gmaps.each do |gmap|
+    @articles.push(gmap.article)
+    end
+    
+  end
+
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,10 +11,6 @@ class StaticPagesController < ApplicationController
   end
 
   def help
-   @map_key = ENV['GOOGLE_MAP_API']
-   
-   binding.pry
-   
   end
   
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,6 +11,10 @@ class StaticPagesController < ApplicationController
   end
 
   def help
+   @map_key = ENV['GOOGLE_MAP_API']
+   
+   binding.pry
+   
   end
   
 end

--- a/app/helpers/maps_helper.rb
+++ b/app/helpers/maps_helper.rb
@@ -1,0 +1,2 @@
+module MapsHelper
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,7 @@ class Article < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes,source: :user
   has_many :notifications,dependent: :destroy
+  has_one :map,dependent: :destroy
 
   default_scope -> {order(created_at: :desc)} 
   validates :user_id, presence: true

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,0 +1,5 @@
+class Map < ApplicationRecord
+  belongs_to :article
+  geocoded_by :address
+  after_validation :geocode
+end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,14 +1,49 @@
 <div id="article_page" class="col-mid-8">
   <h2>タイトル:<%= @article.title %></p></h2>
   <h3>本文：<%= @article.content%></h3>
-
+  <% unless @map.nil? %>
+  <div id="map"></div>
+  <% end %>
   コメント</p>
-  
 
   <%= render 'comments/comment_form' %>
   <%= render 'likes/like' %>
   <div id="comments">
   <%= render @comments %>
   </div>
-
 </div>
+
+<style>
+#map{
+  height: 400px;
+}
+</style>
+
+
+<script>
+  var myLatLng
+  var marker
+
+  if(gon.latitude !== null){
+    latitude = gon.latitude
+  }
+
+  if(gon.longitude !== null){
+    longitude = gon.longitude
+  }
+
+function initMap(){
+   myLatLng = {lat: latitude, lng: longitude}
+ 
+  let map = new google.maps.Map(document.getElementById('map'), {
+  center: myLatLng,
+  zoom: 8
+    });
+  
+   marker = new google.maps.Marker();
+   marker.setPosition(new google.maps.LatLng(latitude,longitude));
+   marker.setMap(map);
+  
+}
+</script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initMap" async defer></script>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,6 +15,7 @@
         <li><%= link_to "いいねした記事", user_likes_path(current_user) %></li>
         <li><%= link_to "プロフィール", user_path(current_user) %></li>
         <li><%= link_to "セッティング", edit_user_path(current_user) %></li>
+        <li><%= link_to "近い記事検索",new_map_path %></li>
         <li>        
         <%= link_to "ログアウト",logout_path,method: :delete %>
         </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,8 +4,11 @@
     <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= include_gon %>
+    
     <%= stylesheet_link_tag    'application', media: 'all',
                                'data-turbolinks-track': 'reload' %>
+    
     <%= javascript_pack_tag 'application',
                                'data-turbolinks-track': 'reload' %>
     <!--[if lt IE 9]>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,9 @@
+<% unless @articles.empty? %>
+<ul class="microposts">
+  <%= render @articles %>
+</ul>
+
+<% else %>
+近い場所での募集はありません
+
+<% end %>

--- a/app/views/maps/new.html.erb
+++ b/app/views/maps/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_with(url:maps_path,method: :get,local: true) do |f|%>
+<%= f.label :area,"位置検索" %>
+<%= f.text_area :area %>
+<%= f.submit "送信" %>
+<% end %>

--- a/app/views/shared/_article_form.html.erb
+++ b/app/views/shared/_article_form.html.erb
@@ -3,6 +3,13 @@
 <div id="article_form" class="field">
   <%= f.label :title, "タイトル" %>
   <%= f.text_area :title %>
+  教える場所
+  <div id='map'></div>
+  <%= f.fields_for :map, @article.build_map do |map| %>   
+    <%= map.hidden_field :latitude %>
+    <%= map.hidden_field :longitude %>
+ 
+  <% end %>
   <%= f.label :content, "本文" %>
   <%= f.rich_text_area :content,placeholder:"入力してください" %>
   <%= f.label :tag_list %>
@@ -11,4 +18,62 @@
   <%= f.file_field :image, accept: "image/jpeg,image/gif,image/png" %>
 </div>
 <div id="article_button"><%= f.submit "投稿！",class:"btn"%></div>
+
 <% end %>
+<button id="del" class="btn" onclick="deleteMarker();">マーカー削除</button>
+ 
+
+
+
+<style>
+#map{
+  height: 400px;
+}
+</style>
+
+<script>
+
+  var marker
+  var myLatLng
+  var map_lat
+  var map_lng
+function initMap(){
+   myLatLng = {lat: 35.68090045006303, lng: 139.76690798417752}
+   map_lat = document.getElementById('article_map_latitude')
+   map_lng = document.getElementById('article_map_longitude')
+   marker = new google.maps.Marker();
+  
+  let map = new google.maps.Map(document.getElementById('map'), {
+  center: myLatLng,
+  zoom: 8
+  });
+  
+
+ google.maps.event.addListener(map, 'click', mylistener);
+
+       //クリックしたときの処理
+  function mylistener(event){
+
+    //markerの位置を設定
+    //event.latLng.lat()でクリックしたところの緯度を取得
+    marker.setPosition(new google.maps.LatLng(event.latLng.lat(), event.latLng.lng()));
+    //marker設置
+    marker.setMap(map);    
+    console.log(event.latLng.lat(), event.latLng.lng());
+    map_lat.value = event.latLng.lat();
+    map_lng.value = event.latLng.lng();
+   
+  }
+
+  
+}
+function deleteMarker(){
+  marker.setMap(null);
+  map_lat.value = "";
+  map_lng.value = "";
+}
+
+
+
+</script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initMap" async defer></script>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -2,16 +2,22 @@
 
 <h1>StaticPages#help</h1>
 <p>Find me in app/views/static_pages/help.html.erb</p>
+ 
+<h2>gmap</h2>
+<div id='map'></div>
 
-<div id="app">
-    <v-app>
-      <v-main>
-        <v-container>
-        <v-btn href="<%=root_path%>"
-            elevation="9" outlined 
-          >ホーム</v-btn>
-        </v-container>
-      </v-main>
-    </v-app>
-</div>
-    
+<style>
+#map{
+  height: 400px;
+}
+</style>
+
+<script>
+function initMap(){
+  let map = new google.maps.Map(document.getElementById('map'), {
+  center: {lat: -34.397, lng: 150.644},
+  zoom: 8
+  });
+}
+</script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initMap" async defer></script>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -5,6 +5,7 @@
  
 <h2>gmap</h2>
 <div id='map'></div>
+<div id='map_name'></div>
 
 <style>
 #map{
@@ -14,10 +15,35 @@
 
 <script>
 function initMap(){
+  var myLatLng = {lat: 35.68090045006303, lng: 139.76690798417752}
+  var marker = new google.maps.Marker();
+  var map_name = document.getElementById('map_name')
+
   let map = new google.maps.Map(document.getElementById('map'), {
-  center: {lat: -34.397, lng: 150.644},
+  center: myLatLng,
   zoom: 8
-  });
+    });
+  
+
+ google.maps.event.addListener(map, 'click', mylistener);
+
+       //クリックしたときの処理
+  function mylistener(event){
+    //marker作成
+    //markerの位置を設定
+    //event.latLng.lat()でクリックしたところの緯度を取得
+    marker.setPosition(new google.maps.LatLng(event.latLng.lat(), event.latLng.lng()));
+    //marker設置
+    marker.setMap(map);    
+    console.log(event.latLng.lat(), event.latLng.lng());
+    map_name.textContent=event.latLng.lat(),event.latLng.lng();
+  }
 }
+
+
+
+
+
+
 </script>
 <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initMap" async defer></script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,6 @@ module CoachApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    
   end
 end

--- a/config/initializers/will_paginate_Array_fix.rb
+++ b/config/initializers/will_paginate_Array_fix.rb
@@ -1,0 +1,1 @@
+require 'will_paginate/array'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,6 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :maps,only: [:index,:new]
   
-  
-  
-
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-end
+  end

--- a/config/webpacker 2.yml
+++ b/config/webpacker 2.yml
@@ -1,0 +1,96 @@
+# Note: You must restart bin/webpack-dev-server for changes to take effect
+
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/cache/webpacker
+  check_yarn_integrity: false
+  webpack_compile_output: true
+
+  # Additional paths webpack should lookup modules
+  # ['app/assets', 'engine/foo/app/assets']
+  resolved_paths: []
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+  # Extract and emit a css file
+  extract_css: false
+
+  static_assets_extensions:
+    - .jpg
+    - .jpeg
+    - .png
+    - .gif
+    - .tiff
+    - .ico
+    - .svg
+    - .eot
+    - .otf
+    - .ttf
+    - .woff
+    - .woff2
+
+  extensions:
+    - .mjs
+    - .js
+    - .sass
+    - .scss
+    - .css
+    - .module.sass
+    - .module.scss
+    - .module.css
+    - .png
+    - .svg
+    - .gif
+    - .jpeg
+    - .jpg
+
+development:
+  <<: *default
+  compile: true
+
+  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    pretty: false
+    headers:
+      'Access-Control-Allow-Origin': '*'
+    watch_options:
+      ignored: '**/node_modules/**'
+
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true

--- a/db/migrate/20201211131848_create_maps.rb
+++ b/db/migrate/20201211131848_create_maps.rb
@@ -1,0 +1,13 @@
+class CreateMaps < ActiveRecord::Migration[6.0]
+  def change
+    create_table :maps do |t|
+    
+    t.references :article, null: false, foreign_key: true
+    t.string :address
+    t.float :latitude
+    t.float :longitude
+
+    t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_043847) do
+ActiveRecord::Schema.define(version: 2020_12_11_131848) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -80,6 +80,16 @@ ActiveRecord::Schema.define(version: 2020_12_10_043847) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["article_id"], name: "fk_rails_86adad7015"
     t.index ["user_id", "article_id"], name: "index_likes_on_user_id_and_article_id", unique: true
+  end
+
+  create_table "maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_maps_on_article_id"
   end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -188,6 +198,7 @@ ActiveRecord::Schema.define(version: 2020_12_10_043847) do
   add_foreign_key "entries", "users"
   add_foreign_key "likes", "articles"
   add_foreign_key "likes", "users"
+  add_foreign_key "maps", "articles"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users"
   add_foreign_key "profiles", "users"

--- a/spec/factories/maps.rb
+++ b/spec/factories/maps.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :map do
+    
+  end
+end

--- a/spec/helpers/maps_helper_spec.rb
+++ b/spec/helpers/maps_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the MapsHelper. For example:
+#
+# describe MapsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe MapsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Map, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/maps_request_spec.rb
+++ b/spec/requests/maps_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Maps", type: :request do
+
+end


### PR DESCRIPTION
○マップ機能追加
・Mapモデル、コントローラ作成
・MapモデルはArticleモデルの子モデルに指定
・記事作成時、Map上にマーカーを設置でき、その緯度経度を保存できる。

○近い記事検索機能追加
・入力した文字列をGoogleMapから検索し、そこから20km以内にマーカー設置して保存している記事一覧を取得できる。

※近い記事検索機能のページネートができていない。理由は取得した記事が配列だから。
なにか工夫が必要。kaminariに変えるなど。